### PR TITLE
Rename Observant protocol to ObservableSubjectManager

### DIFF
--- a/CombineTest/Coordinators/Coordinator.swift
+++ b/CombineTest/Coordinators/Coordinator.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Combine
 
-class Coordinator: Observant {
+class Coordinator: ObservableSubjectManager {
     var editTabNavigationController: UINavigationController = UINavigationController()
     var viewTabNavigationController: UINavigationController = UINavigationController()
     var tabBar: UITabBarController = UITabBarController()

--- a/CombineTest/Protocols/ObserverProtocols.swift
+++ b/CombineTest/Protocols/ObserverProtocols.swift
@@ -18,14 +18,14 @@ protocol Observer: class {
     func update(forResult result: Result<CountModel, Error>)
 }
 
-protocol Observant: class {
+protocol ObservableSubjectManager: class {
     var subject: PassthroughSubject<CountModel, Error> { get }
     var publisher: AnyPublisher<CountModel, Error> { get }
     
     func setupObserver(_ observer: Observer)
 }
 
-extension Observant {
+extension ObservableSubjectManager {
     func setupObserver(_ observer: Observer) {
         observer.cancellable = self.publisher.sink(receiveCompletion: { (subscriberCompletion) in
             switch subscriberCompletion {


### PR DESCRIPTION
I renamed the Observant protocol to ObservableSubjectManager for better clarity.