### PR TITLE
Add CountModel status enum to handle possible loadings and errors

### DIFF
--- a/CombineTest.xcodeproj/project.pbxproj
+++ b/CombineTest.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		874DD51D24E582670029CB13 /* ObserverProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874DD51C24E582670029CB13 /* ObserverProtocols.swift */; };
 		874DD52624E5907E0029CB13 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 874DD52424E5907D0029CB13 /* LaunchScreen.storyboard */; };
 		874DD52724E5907E0029CB13 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 874DD52524E5907D0029CB13 /* Main.storyboard */; };
+		876395B524E74294005D86D9 /* ObservableCountStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876395B424E74294005D86D9 /* ObservableCountStatus.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		874DD51C24E582670029CB13 /* ObserverProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverProtocols.swift; sourceTree = "<group>"; };
 		874DD52424E5907D0029CB13 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		874DD52524E5907D0029CB13 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		876395B424E74294005D86D9 /* ObservableCountStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableCountStatus.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				874DD51624E44B5E0029CB13 /* CountModel.swift */,
+				876395B424E74294005D86D9 /* ObservableCountStatus.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -211,6 +214,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				874DD51724E44B5E0029CB13 /* CountModel.swift in Sources */,
+				876395B524E74294005D86D9 /* ObservableCountStatus.swift in Sources */,
 				874DD51924E46D2C0029CB13 /* Coordinator.swift in Sources */,
 				874DD4FF24E441AB0029CB13 /* AppDelegate.swift in Sources */,
 				874DD51424E443FA0029CB13 /* TestViewController.swift in Sources */,

--- a/CombineTest/Coordinators/Coordinator.swift
+++ b/CombineTest/Coordinators/Coordinator.swift
@@ -14,8 +14,8 @@ class Coordinator: ObservableSubjectManager {
     var viewTabNavigationController: UINavigationController = UINavigationController()
     var tabBar: UITabBarController = UITabBarController()
     
-    var subject: PassthroughSubject<CountModel, Error> = PassthroughSubject<CountModel, Error>()
-    var publisher: AnyPublisher<CountModel, Error> {
+    var subject: PassthroughSubject<ObservableCountStatus, Never> = PassthroughSubject<ObservableCountStatus, Never>()
+    var publisher: AnyPublisher<ObservableCountStatus, Never> {
         // Here we're "erasing" the information of which type
         // that our subject actually is, only letting our outside
         // code know that it's a read-only publisher:
@@ -24,7 +24,7 @@ class Coordinator: ObservableSubjectManager {
     
     var countModel: CountModel {
         didSet {
-            subject.send(countModel)
+            subject.send(.didLoad(countModel))
         }
     }
     

--- a/CombineTest/Models/ObservableCountStatus.swift
+++ b/CombineTest/Models/ObservableCountStatus.swift
@@ -1,0 +1,18 @@
+//
+//  ObservableCountStatus.swift
+//  CombineTest
+//
+//  Created by Zakaria Bounouar on 2020-08-14.
+//  Copyright © 2020 Zakaria Bounouar. All rights reserved.
+//
+
+import Foundation
+
+enum ObservableCountStatus {
+    // This status let's the observer know that the model has finished loading
+    case didLoad(CountModel)
+    // This status let's the observer know that the model is loading
+    case isLoading
+    // This status is in case of errors
+    case error(Error)
+}

--- a/CombineTest/Protocols/ObserverProtocols.swift
+++ b/CombineTest/Protocols/ObserverProtocols.swift
@@ -15,28 +15,20 @@ import Combine
 protocol Observer: class {
     var cancellable: AnyCancellable? { get set }
     
-    func update(forResult result: Result<CountModel, Error>)
+    func update(forStatus status: ObservableCountStatus)
 }
 
 protocol ObservableSubjectManager: class {
-    var subject: PassthroughSubject<CountModel, Error> { get }
-    var publisher: AnyPublisher<CountModel, Error> { get }
+    var subject: PassthroughSubject<ObservableCountStatus, Never> { get }
+    var publisher: AnyPublisher<ObservableCountStatus, Never> { get }
     
     func setupObserver(_ observer: Observer)
 }
 
 extension ObservableSubjectManager {
     func setupObserver(_ observer: Observer) {
-        observer.cancellable = self.publisher.sink(receiveCompletion: { (subscriberCompletion) in
-            switch subscriberCompletion {
-            case .failure(let error):
-                observer.update(forResult: .failure(error))
-            case .finished:
-                // Not sure what to do here
-                break
-            }
-        }, receiveValue: { countModel in
-            observer.update(forResult: .success(countModel))
+        observer.cancellable = self.publisher.sink(receiveValue: { subjectStatus in
+            observer.update(forStatus: subjectStatus)
         })
     }
 }

--- a/CombineTest/ViewControllers/TestViewController.swift
+++ b/CombineTest/ViewControllers/TestViewController.swift
@@ -106,13 +106,12 @@ class TestViewController: UIViewController, Observer {
     
     // MARK: - Observer method
     
-    func update(forResult result: Result<CountModel, Error>) {
-        switch result {
-        case .success(let newCountModel):
-            self.countModel = newCountModel
-        case .failure(let error):
-            debugPrint(error)
-            // Could show an error message or something here.
+    func update(forStatus status: ObservableCountStatus) {
+        switch status {
+        case .didLoad(let countModel):
+            self.countModel = countModel
+        default:
+            break
         }
     }
     


### PR DESCRIPTION
Adde ObservableCountStatus enum to handle possible loadings and errors.